### PR TITLE
option for skip-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ For more info please visit the official site: http://www.aurelia.io/
   ```
 8. Browse to [http://localhost:9000](http://localhost:9000) to see the app. You can make changes in the code found under `src` and the browser should auto-refresh itself as you save files.
 
+## Command line options
+yo aurelia --skip-install will skip the npm and jspm install.
 
 ## Creating a new page
 In order to create a new Aurelia Page just enter the following command inside your project root:

--- a/app/index.js
+++ b/app/index.js
@@ -1,35 +1,49 @@
 var fs = require('fs');
-var generators = require('yeoman-generator');
+var yeoman = require('yeoman-generator');
 
-var Generator = module.exports = generators.Base.extend({
+var Generator = module.exports = yeoman.generators.Base.extend({
+  constructor: function(){
+    yeoman.generators.Base.apply(this, arguments);
+    this.option('skip-install');
+  },
   init: function () {
     var done = this.async();
-    var that = this;
 
     var ghdownload = require('download-github-repo')
       , execFile = require('child_process').execFile;
 
-    console.log(this.destinationRoot());
+    this.log(this.destinationRoot());
 
     ghdownload("aurelia/skeleton-navigation", this.destinationRoot(), function(err) {
       if(err !== undefined) {
         this.env.error(err);
       } else {
-        console.log('Download complete');
+        this.log('Download complete');
       }
-
       done();
-    });
+    }.bind(this));
   },
 
   executeNPMInstall: function () {
-    console.log('Executing NPM install');
-    this.npmInstall();
+    if (!this.options['skip-install']){
+      this.log('Executing NPM install');
+      this.npmInstall();
+    }
+    else{
+    this.log('NPM install deliberately skipped');
+    };
   },
 
   runJSPM: function() {
-    console.log('Executing JSPM install');
-    this.spawnCommand('jspm', ['install']);
+
+    if (!this.options['skip-install']){
+      this.log('Executing JSPM install');
+      this.spawnCommand('jspm', ['install']);
+    }
+    else{
+      this.log('JSPM install deliberately skipped');
+    
+    };
   }
 });
 


### PR DESCRIPTION
Hi,

I did an update for a skip-install option. This is probably not useful when running this yeoman generator 'stand-alone', but it can be useful when this generator is integrated with others (what I'm currently trying to do :) ).
I replaced also the console loggings with this.console and used a .bind(this) on the ghdownload method so that the 'this context' gets preserved.
Thanks for integrating this small change.
Cheers and warm regards
Bis bald
paul.
